### PR TITLE
Adds the ability for iftb patch merging to extend the loca table up to a new glyph count

### DIFF
--- a/src/merger.cc
+++ b/src/merger.cc
@@ -328,11 +328,10 @@ void iftb::dumpChunk(std::ostream &os, std::istream &is) {
     }
 }
  
-std::string iftb::decodeChunk(char *buf, size_t length) {
+std::string iftb::decodeChunk(const char *buf, size_t length) {
     uint32_t l;
 
-    simpleistream sis;
-    sis.rdbuf()->pubsetbuf(buf, length);
+    simpleistream sis(buf, length);
     sis.seekg(28);  // length offset
     readObject(sis, l);
 
@@ -360,7 +359,7 @@ std::string iftb::decodeChunk(char *buf, size_t length) {
    When buf == NULL the string will be treated as the input, which will
    only be changed if it needs to be decoded (decompressed)
  */
-uint32_t iftb::decodeBuffer(char *buf, uint32_t length, std::string &s,
+uint32_t iftb::decodeBuffer(const char *buf, uint32_t length, std::string &s,
                            float reserveExtra) {
     bool is_woff2 = false, is_compressed_chunk = false;
     bool in_string = (buf == NULL);

--- a/src/merger.h
+++ b/src/merger.h
@@ -25,8 +25,8 @@ it.
 namespace iftb {
     class merger;
     void dumpChunk(std::ostream &os, std::istream &is);
-    std::string decodeChunk(char *buf, size_t length);
-    uint32_t decodeBuffer(char *buf, uint32_t length, std::string &s,
+    std::string decodeChunk(const char *buf, size_t length);
+    uint32_t decodeBuffer(const char *buf, uint32_t length, std::string &s,
                           float reserveExtra = 0.0);
 }
 
@@ -97,4 +97,3 @@ private:
     uint32_t glyfcoff {0}, glyfnoff {0}, glyfclen {0}, glyfnlen {0};
     uint32_t locacoff {0}, locanoff {0}, localen {0}, fontend {0};
 };
-

--- a/src/merger.h
+++ b/src/merger.h
@@ -61,7 +61,7 @@ public:
         glyphCount = charStringOff = gvarDataOff = 0;
         t1tag = t1off = t1clen = t1nlen = 0;
         glyfcoff = glyfnoff = glyfclen = glyfnlen = 0;
-        locacoff = locanoff = localen = fontend = 0;
+        locacoff = locanoff = locaclen = locanlen = fontend = 0;
     }
     void setID(uint32_t i[4]) {
         id[0] = i[0];
@@ -95,5 +95,6 @@ private:
     uint32_t glyphCount {0}, charStringOff {0}, gvarDataOff {0};
     uint32_t t1tag {0}, t1off {0}, t1clen {0}, t1nlen {0};
     uint32_t glyfcoff {0}, glyfnoff {0}, glyfclen {0}, glyfnlen {0};
-    uint32_t locacoff {0}, locanoff {0}, localen {0}, fontend {0};
+    uint32_t locacoff {0}, locanoff {0}, locaclen {0}, locanlen {0};
+    uint32_t fontend {0};
 };


### PR DESCRIPTION
If the loca in the base font is shorter than it should be based on the glyph count provided to calcLayout() then the merger will extend it to match the new glyph count. So far I've only implemented this for loca, but a similar approach could likely be followed for CFF/CFF2/gvar.